### PR TITLE
Work April 2018

### DIFF
--- a/config/skim_2017_sync_mib.cfg
+++ b/config/skim_2017_sync_mib.cfg
@@ -1,0 +1,132 @@
+### how to run on my file:
+### skimNtuple.exe filelist_sync13Sett.txt output_HH_sync_14Set.root 10.0 0  config/skim_2016_sync.cfg  0  1.0 -999.0 0  0  0 0 1
+
+[selections]
+
+# do not select events with at least two jets in the final state
+# false : only >= 2 b jet ; true : all events
+beInclusive = true
+
+[parameters]
+
+PUjetIDminCut       = -999.9
+# PUjetIDminCut       = -0.5
+# 0 ; don't pass PF Jet ID;
+# 1: tight,
+# 2: tightLepVeto
+PFjetIDWP           = 1
+# if false, SS events are saved
+# saveOS = 0 : save the same sign events only
+# saveOS = 1 : save the opposite sign events only
+# saveOS = -1 : save both SS and OS events
+saveOS              = -1
+# minimal distance required between any jets and the two leptons of the event
+# when counting the jets in the jet selection and when choosing the two bjet candidates
+# additional jets do NOT undergo this selection
+lepCleaningCone     = 0.5
+# choose the algo used to ID the b-jets
+# 1 = the two jets surviving selections with largest btag value
+# 2 = the two jets surviving selections with largest pT
+bChoiceFlag         = 1
+# choose the MC to be reweighted 
+# 25 = 25ns Spring15  
+# 50 = 50ns Spring15
+# 2016: 2016 miniAODv2 MC
+PUReweightMC        = 0
+# choose the target data taking period for the reweighting 
+# 25 = 2015C/2015D at 25 ns
+# 50 = 2015B at 50 ns
+# 26: profile of 2016 2.6/fb -- 40: profile of 2016 3.99/fb -- 92: profile of 2016 9.2/fb -- 129: profile of 2016 12.9/fb
+PUReweighttarget    = 0
+# skipping the isolation
+lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu
+#lepSelections       = Vertex-LepID-pTMin-etaMax
+#lepSelections       = Vertex-LepID-pTMin-etaMax-againstEle-againstMu-Iso
+# default selections
+# lepSelections       = All
+# invert isolation
+# lepSelections       = InvertIzo
+maxNjetsSaved      = 999
+# tauhtauh pair choice. NB: does not affect mutau, etau
+# 0: order the pair in pt, then compare leg1 iso, pt, then leg2 iso, pt (default in LLRFramework)
+# 1: HTauTau-like order: make both AB and BA pairs to be sorted
+pairStrategy = 1
+# debugEvent, prints some couts for this event, -1 for no debug
+debugEvent = 9999999
+applyTriggersMC = true
+
+
+# Use specific lines for cross triggers, if no cross trigger is used just put: crossTauTau/crossMuTau/crossEleTau = NULL
+[triggersData]
+# 94X, 2017 v2
+TauTau =  HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET90_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET100_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET110_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET130_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v
+MuTau  = HLT_IsoMu24_v, HLT_IsoMu27_v
+EleTau = HLT_Ele32_WPTight_Gsf_v, HLT_Ele35_WPTight_Gsf_v
+EleMu  = HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v , HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v
+MuMu   = HLT_IsoMu24_v, HLT_IsoMu27_v
+EleEle = HLT_Ele32_WPTight_Gsf_v, HLT_Ele35_WPTight_Gsf_v
+crossTauTau = HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v, HLT_DoubleMediumChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v, HLT_DoubleMediumChargedIsoPFTau40_Trk1_eta2p1_Reg_v, HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v, HLT_DoubleTightChargedIsoPFTau35_Trk1_eta2p1_Reg_v, HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v, HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v, HLT_DoubleTightChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v,  HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v, HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v, HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v
+crossMuTau  = HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1_v, HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_eta2p1_SingleL1_v, HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_TightID_CrossL1_v, HLT_IsoMu20_eta2p1_MediumChargedIsoPFTau27_eta2p1_CrossL1_v, HLT_IsoMu20_eta2p1_MediumChargedIsoPFTau27_eta2p1_TightID_CrossL1_v, HLT_IsoMu20_eta2p1_TightChargedIsoPFTau27_eta2p1_CrossL1_v, HLT_IsoMu20_eta2p1_TightChargedIsoPFTau27_eta2p1_TightID_CrossL1_v, HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_eta2p1_TightID_SingleL1_v, HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau20_eta2p1_SingleL1_v, HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau20_eta2p1_TightID_SingleL1_v, HLT_IsoMu24_eta2p1_TightChargedIsoPFTau20_eta2p1_SingleL1_v, HLT_IsoMu24_eta2p1_TightChargedIsoPFTau20_eta2p1_TightID_SingleL1_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET90_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET100_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET110_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET130_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v
+crossEleTau = HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_TightID_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_MediumChargedIsoPFTau30_eta2p1_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_MediumChargedIsoPFTau30_eta2p1_TightID_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_TightChargedIsoPFTau30_eta2p1_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_TightChargedIsoPFTau30_eta2p1_TightID_CrossL1_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET90_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET100_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET110_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET130_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v
+
+
+[triggersMC]
+# 94X, 2017 v2
+TauTau = HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET90_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET100_v,HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET110_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET130_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v
+MuTau  = HLT_IsoMu24_v, HLT_IsoMu27_v
+EleTau = HLT_Ele32_WPTight_Gsf_v, HLT_Ele35_WPTight_Gsf_v
+EleMu  = HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v , HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v
+MuMu   = HLT_IsoMu24_v, HLT_IsoMu27_v
+EleEle = HLT_Ele32_WPTight_Gsf_v, HLT_Ele35_WPTight_Gsf_v
+crossTauTau = HLT_DoubleMediumChargedIsoPFTau35_Trk1_eta2p1_Reg_v, HLT_DoubleMediumChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v, HLT_DoubleMediumChargedIsoPFTau40_Trk1_eta2p1_Reg_v, HLT_DoubleMediumChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v, HLT_DoubleTightChargedIsoPFTau35_Trk1_eta2p1_Reg_v, HLT_DoubleTightChargedIsoPFTau35_Trk1_TightID_eta2p1_Reg_v, HLT_DoubleTightChargedIsoPFTau40_Trk1_eta2p1_Reg_v, HLT_DoubleTightChargedIsoPFTau40_Trk1_TightID_eta2p1_Reg_v, HLT_VBF_DoubleLooseChargedIsoPFTau20_Trk1_eta2p1_Reg_v, HLT_VBF_DoubleMediumChargedIsoPFTau20_Trk1_eta2p1_Reg_v, HLT_VBF_DoubleTightChargedIsoPFTau20_Trk1_eta2p1_Reg_v
+crossMuTau  = HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_eta2p1_SingleL1_v, HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_CrossL1_v, HLT_IsoMu20_eta2p1_LooseChargedIsoPFTau27_eta2p1_TightID_CrossL1_v, HLT_IsoMu20_eta2p1_MediumChargedIsoPFTau27_eta2p1_CrossL1_v, HLT_IsoMu20_eta2p1_MediumChargedIsoPFTau27_eta2p1_TightID_CrossL1_v, HLT_IsoMu20_eta2p1_TightChargedIsoPFTau27_eta2p1_CrossL1_v, HLT_IsoMu20_eta2p1_TightChargedIsoPFTau27_eta2p1_TightID_CrossL1_v, HLT_IsoMu24_eta2p1_LooseChargedIsoPFTau20_eta2p1_TightID_SingleL1_v, HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau20_eta2p1_SingleL1_v, HLT_IsoMu24_eta2p1_MediumChargedIsoPFTau20_eta2p1_TightID_SingleL1_v, HLT_IsoMu24_eta2p1_TightChargedIsoPFTau20_eta2p1_SingleL1_v, HLT_IsoMu24_eta2p1_TightChargedIsoPFTau20_eta2p1_TightID_SingleL1_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET90_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET100_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET110_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET130_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v
+crossEleTau = HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_LooseChargedIsoPFTau30_eta2p1_TightID_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_MediumChargedIsoPFTau30_eta2p1_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_MediumChargedIsoPFTau30_eta2p1_TightID_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_TightChargedIsoPFTau30_eta2p1_CrossL1_v, HLT_Ele24_eta2p1_WPTight_Gsf_TightChargedIsoPFTau30_eta2p1_TightID_CrossL1_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET90_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET100_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET110_v, HLT_MediumChargedIsoPFTau50_Trk30_eta2p1_1pr_MET130_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_v, HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1_1pr_v
+
+
+[TMVA]
+
+variables                   = HH_deltaPhi, tauHMet_deltaPhi, bHMet_deltaPhi, ditau_deltaR, dib_deltaR
+spectatorsPresent           = true
+spectators                  = HH_mass, HHKin_mass
+#eventWeight                 = MC_weight
+#variabletransformation      = I:N
+# comment a training --> corresponding branch not computed in output
+#weightsMuTau  = /home/llr/cms/cadamuro/HHKlubAnalysis/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_MuTauKine.weights.xml
+#weightsETau   = /home/llr/cms/cadamuro/HHKlubAnalysis/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_ETauKine.weights.xml
+#weightsLepTau = /home/llr/cms/cadamuro/CleanKLUB/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_LepTauKine.weights.xml
+weightsMuTau  = /gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_MuTauKine.weights.xml
+weightsETau   = /gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_ETauKine.weights.xml
+weightsLepTau = /gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_LepTauKine.weights.xml
+
+#weightsMuTau  = /home/llr/cms/amendola/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_MuTauKine.weights.xml
+#weightsETau   = /home/llr/cms/amendola/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_ETauKine.weights.xml
+#weightsLepTau = /home/llr/cms/amendola/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_LepTauKine.weights.xml
+
+# unused training
+#weightsTauTau = /home/llr/cms/ortona/diHiggs/CMSSW_7_4_7/src/KLUBAnalysis/weights/HTauTauTree_BDTG_TauTauKine.weights.xml
+
+computeMVA = true
+
+[BDTResonant]
+# for variables: write as my_name:BDT_xml_name , as BDT is produced with different names
+variables    = dau1MET_deltaphi:dphi_mumet , tauHMet_deltaPhi:dphi_metsv , dib_deltaR:dR_bb , ditau_deltaR:dR_taumu , mT1:pfmt_1 , mT2:pfmt_2 , bHMet_deltaPhi:dphi_bbmet , HH_deltaPhi:dphi_bbsv
+#weights    = /home/llr/cms/cadamuro/HH2016/CMSSW_7_4_7/src/KLUBAnalysis/weights/TMVAClassification_BDT_full_mass_iso_nodrbbsv.weights.xml
+weights   = /gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_7_4_7/src/KLUBAnalysis/weights/TMVAClassification_BDT_full_mass_iso_nodrbbsv.weights.xml
+#weights   = /home/llr/cms/amendola/CMSSW_7_4_7/src/KLUBAnalysis/weights/TMVAClassification_BDT_full_mass_iso_nodrbbsv.weights.xml
+computeMVA = true
+
+
+[bRegression]
+computeBregr = false
+weights = /gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_7_4_7/src/KLUBAnalysis/weights/TMVARegression_BDTG.weights.xml
+#weights = /home/llr/cms/amendola/CMSSW_7_4_7/src/KLUBAnalysis/weights/TMVARegression_BDTG.weights.xml
+
+[bTagScaleFactors]
+#SFFile  = /home/llr/cms/amendola/CMSSW_7_4_7/src/KLUBAnalysis/weights/CSVv2_94XSF_V1_B_F.csv
+SFFile  = /gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_7_4_7/src/KLUBAnalysis/weights/CSVv2_94XSF_V1_B_F.csv
+
+#effFile = /home/llr/cms/amendola/CMSSW_7_4_7/src/KLUBAnalysis/weights/bTagEfficiencies_94X_2018WPs_Fall17MC.root
+effFile = /gwpool/users/brivio/Hhh_1718/syncFeb2018/CMSSW_7_4_7/src/KLUBAnalysis/weights/bTagEfficiencies_94X_2018WPs_Fall17MC.root
+
+[debug]
+skipTriggers = false

--- a/interface/smallTree.h
+++ b/interface/smallTree.h
@@ -67,6 +67,10 @@ struct smallTree
       
       m_met_phi = -1. ;
       m_met_et = -1. ;
+      m_met_phi_jetup = -1.  ; //FRA - shifted MET
+      m_met_et_jetup = -1.   ; //
+      m_met_phi_jetdown = -1.; //
+      m_met_et_jetdown = -1. ; //
       m_met_et_corr =-1.;
       m_met_cov00 = -1.;
       m_met_cov01 = -1.;
@@ -518,6 +522,10 @@ struct smallTree
 
       m_smallT->Branch ("met_phi", &m_met_phi, "met_phi/F") ;
       m_smallT->Branch ("met_et", &m_met_et, "met_et/F") ;
+      m_smallT->Branch ("met_phi_jetup", &m_met_phi_jetup, "met_phi_jetup/F") ;       //FRA - shifted MET
+      m_smallT->Branch ("met_et_jetup", &m_met_et_jetup, "met_et_jetup/F") ;          //
+      m_smallT->Branch ("met_phi_jetdown", &m_met_phi_jetdown, "met_phi_jetdown/F") ; //
+      m_smallT->Branch ("met_et_jetdown", &m_met_et_jetdown, "met_et_jetdown/F") ;    //
       m_smallT->Branch ("met_et_corr", &m_met_et_corr, "met_et_corr/F") ;
       m_smallT->Branch ("met_cov00", &m_met_cov00, "met_cov00/F") ;
       m_smallT->Branch ("met_cov01", &m_met_cov01, "met_cov01/F") ;
@@ -960,6 +968,10 @@ struct smallTree
   // MET
   Float_t m_met_phi ;
   Float_t m_met_et ;
+  Float_t m_met_phi_jetup ;   //FRA - shifted MET
+  Float_t m_met_et_jetup ;    //
+  Float_t m_met_phi_jetdown ; //
+  Float_t m_met_et_jetdown ;  //
   Float_t m_met_et_corr;
   Float_t m_met_cov00;
   Float_t m_met_cov01;

--- a/test/skimNtuple.cpp
+++ b/test/skimNtuple.cpp
@@ -2274,8 +2274,7 @@ int main (int argc, char** argv)
 	    }  
 	  else if (theBigTree.particleType->at (iLep) == 0) // muons
 	    {
-	      //if (!oph.muBaseline (&theBigTree, iLep, 10., 2.4, 0.3, OfflineProducerHelper::MuLoose)) continue ;
-	      if (!oph.muBaseline (&theBigTree, iLep, 10., 2.4, 0.3, OfflineProducerHelper::MuMedium)) continue ; //FRA: syncFeb2018
+	      if (!oph.muBaseline (&theBigTree, iLep, 10., 2.4, 0.3, OfflineProducerHelper::MuLoose)) continue ;
 	    }
 	  else if (theBigTree.particleType->at (iLep) == 1) // electrons
 	    {

--- a/test/skimNtuple.cpp
+++ b/test/skimNtuple.cpp
@@ -257,6 +257,44 @@ vector<int> findSubjetIdxs (unsigned int iFatJet, bigTree & theBigTree)
 
 
 // ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -
+// get shifted MET
+TVector2 getShiftedMET (float shift, TVector2 MET, bigTree & theBigTree)
+{
+  double corrMETx = MET.Px();
+  double corrMETy = MET.Py();
+
+  for (unsigned int iJet = 0 ; iJet < theBigTree.jets_px->size () ; ++iJet)
+  {
+    // build original jet
+    TLorentzVector tlv_jet (theBigTree.jets_px->at(iJet), theBigTree.jets_py->at(iJet), theBigTree.jets_pz->at(iJet), theBigTree.jets_e->at(iJet));
+
+    // get uncertainty
+    double unc = theBigTree.jets_jecUnc->at(iJet);
+
+    // build shifted jet
+    TLorentzVector tlv_jet_shifted = tlv_jet;
+    tlv_jet_shifted.SetPtEtaPhiE(
+        (1.+shift*unc) * tlv_jet.Pt(),
+        tlv_jet.Eta(),
+        tlv_jet.Phi(),
+        (1.+shift*unc) * tlv_jet.E()
+        );
+
+    // shift MET - first the original jet
+    corrMETx += tlv_jet.Px();
+    corrMETy += tlv_jet.Py();
+
+    // shift MET - then the shifted jet
+    corrMETx -= tlv_jet_shifted.Px();
+    corrMETy -= tlv_jet_shifted.Py();
+  }
+
+  TVector2 shiftedMET(corrMETx, corrMETy);
+
+  return shiftedMET;
+}
+
+// ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- -
 // turn on function for trigger reweight
 
 float turnOnCB(float x, float m0, float sigma, float alpha, float n, float norm)
@@ -1928,6 +1966,15 @@ int main (int argc, char** argv)
       theSmallTree.m_met_cov01 = theBigTree.MET_cov01->at (chosenTauPair);
       theSmallTree.m_met_cov10 = theBigTree.MET_cov10->at (chosenTauPair);
       theSmallTree.m_met_cov11 = theBigTree.MET_cov11->at (chosenTauPair);
+
+      //shifted MET
+      TVector2 vMET_jetup   = getShiftedMET(+1., vMET, theBigTree);
+      TVector2 vMET_jetdown = getShiftedMET(-1., vMET, theBigTree);
+      theSmallTree.m_met_phi_jetup   = vMET_jetup.Phi();
+      theSmallTree.m_met_et_jetup    = vMET_jetup.Mod();
+      theSmallTree.m_met_phi_jetdown = vMET_jetdown.Phi();
+      theSmallTree.m_met_et_jetdown  = vMET_jetdown.Mod();
+
       theSmallTree.m_mT1       = theBigTree.mT_Dau1->at (chosenTauPair) ;
       theSmallTree.m_mT2       = theBigTree.mT_Dau2->at (chosenTauPair) ;
 
@@ -2516,14 +2563,16 @@ int main (int argc, char** argv)
 	  theSmallTree.m_met_et_corr = theBigTree.met - tlv_neutrinos.Et() ;
 
 	  const TVector2 ptmiss = TVector2(METx, METy) ;
-	  //TVector2 ptmiss = TVector2(METx,METy);
 	  TMatrixD metcov (2, 2) ;
 	  metcov (0,0) = theBigTree.MET_cov00->at (chosenTauPair) ;
 	  metcov (1,0) = theBigTree.MET_cov10->at (chosenTauPair) ;
 	  metcov (0,1) = theBigTree.MET_cov01->at (chosenTauPair) ;    
 	  metcov (1,1) = theBigTree.MET_cov11->at (chosenTauPair) ;
+	  const TMatrixD stableMetCov = metcov;
 
-	  const TMatrixD stableMetCov = metcov; 
+      const TVector2 ptmiss_jetup   = getShiftedMET(+1., ptmiss, theBigTree);
+      const TVector2 ptmiss_jetdown = getShiftedMET(-1., ptmiss, theBigTree);
+
 	  theSmallTree.m_bH_pt = tlv_bH.Pt () ;
 	  theSmallTree.m_bH_eta = tlv_bH.Eta () ;
 	  theSmallTree.m_bH_phi = tlv_bH.Phi () ;
@@ -2576,8 +2625,8 @@ int main (int argc, char** argv)
 	      HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet_raw, tlv_secondBjet_raw, tlv_firstLepton, tlv_secondLepton,  ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
 	      HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw_tauup = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet_raw, tlv_secondBjet_raw, tlv_firstLepton_tauup, tlv_secondLepton_tauup,  ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
 	      HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw_taudown = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet_raw, tlv_secondBjet_raw, tlv_firstLepton_taudown, tlv_secondLepton_taudown,  ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
-	      HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw_jetup = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet_raw_jetup, tlv_secondBjet_raw_jetup, tlv_firstLepton, tlv_secondLepton,  ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
-	      HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw_jetdown = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet_raw_jetdown, tlv_secondBjet_raw_jetdown, tlv_firstLepton, tlv_secondLepton,  ptmiss, stableMetCov, bjet1_JER, bjet2_JER) ;
+	      HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw_jetup = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet_raw_jetup, tlv_secondBjet_raw_jetup, tlv_firstLepton, tlv_secondLepton,  ptmiss_jetup, stableMetCov, bjet1_JER, bjet2_JER) ;
+	      HHKinFit2::HHKinFitMasterHeavyHiggs kinFitsraw_jetdown = HHKinFit2::HHKinFitMasterHeavyHiggs(tlv_firstBjet_raw_jetdown, tlv_secondBjet_raw_jetdown, tlv_firstLepton, tlv_secondLepton,  ptmiss_jetdown, stableMetCov, bjet1_JER, bjet2_JER) ;
 
 	      //           kinFits.setAdvancedBalance (&ptmiss, metcov) ;
 	      //           kinFits.setSimpleBalance (ptmiss.Pt (),10) ; //alternative which uses only the absolute value of ptmiss in the fit
@@ -2858,6 +2907,8 @@ int main (int argc, char** argv)
 	      double mVisB_jetup = tlv_secondBjet_raw_jetup.M(); // mass of visible object on side B. 
 	      double pxB_jetup = tlv_secondBjet_raw_jetup.Px(); // x momentum of visible object on side B.
 	      double pyB_jetup = tlv_secondBjet_raw_jetup.Py(); // y momentum of visible object on side B.
+          double pxMiss_jetup = tlv_firstLepton.Px() + tlv_secondLepton.Px() + ptmiss_jetup.Px(); // shiftedMET_up
+          double pyMiss_jetup = tlv_firstLepton.Py() + tlv_secondLepton.Py() + ptmiss_jetup.Py(); // shiftedMET_up
 
 	      double mVisA_jetdown = tlv_firstBjet_raw_jetdown.M(); // mass of visible object on side A.  
 	      double pxA_jetdown = tlv_firstBjet_raw_jetdown.Px(); // x momentum of visible object on side A.
@@ -2865,6 +2916,8 @@ int main (int argc, char** argv)
 	      double mVisB_jetdown = tlv_secondBjet_raw_jetdown.M(); // mass of visible object on side B. 
 	      double pxB_jetdown = tlv_secondBjet_raw_jetdown.Px(); // x momentum of visible object on side B.
 	      double pyB_jetdown = tlv_secondBjet_raw_jetdown.Py(); // y momentum of visible object on side B.
+          double pxMiss_jetdown = tlv_firstLepton.Px() + tlv_secondLepton.Px() + ptmiss_jetdown.Px(); // shiftedMET_up
+          double pyMiss_jetdown = tlv_firstLepton.Py() + tlv_secondLepton.Py() + ptmiss_jetdown.Py(); // shiftedMET_up
 
 
 	      double desiredPrecisionOnMt2 = 0; // Must be >=0.  If 0 alg aims for machine precision.  if >0, MT2 computed to supplied absolute precision.
@@ -2895,14 +2948,14 @@ int main (int argc, char** argv)
 	      double MT2_jetup =  asymm_mt2_lester_bisect::get_mT2(
 								   mVisA_jetup, pxA_jetup, pyA_jetup,
 								   mVisB_jetup, pxB_jetup, pyB_jetup,
-								   pxMiss, pyMiss,
+								   /*pxMiss, pyMiss,*/ pxMiss_jetup, pyMiss_jetup, // shiftedMET
 								   chiA, chiB,
 								   desiredPrecisionOnMt2);
 
 	      double MT2_jetdown =  asymm_mt2_lester_bisect::get_mT2(
 								     mVisA_jetdown, pxA_jetdown, pyA_jetdown,
 								     mVisB_jetdown, pxB_jetdown, pyB_jetdown,
-								     pxMiss, pyMiss,
+								     /*pxMiss, pyMiss,*/ pxMiss_jetdown, pyMiss_jetdown, // shiftedMET
 								     chiA, chiB,
 								     desiredPrecisionOnMt2);
 


### PR DESCRIPTION
- Fixed bug in skimNtuple for lepton veto: MuMedium --> MuLoose (was changed by mistake a while ago)
- added skim_2017_config_mib.cfg
- added function to calculate shifted MET (according to jets JEC) and 4 branches to store shifted MET: for now the only considered shift for jets is the total JEC, not the 27 different uncertainty sources